### PR TITLE
Add Docker Compose deployment guidance

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,70 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: ["main"]
+    tags: ["v*"]
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/wickedyoda/glkvm-cloud
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=sha
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: wickedyoda
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          tag_args=()
+          while IFS= read -r tag; do
+            [[ -z "$tag" ]] && continue
+            tag_args+=(--tag "$tag")
+          done <<< "$TAGS"
+          if [[ ${#tag_args[@]} -eq 0 ]]; then
+            tag_args+=(--tag "$IMAGE_NAME:latest")
+          fi
+          echo "Building image with tags: ${tag_args[*]}"
+          python3 scripts/build_docker_image.py \
+            --image "$IMAGE_NAME" \
+            --platform linux/amd64 \
+            --push \
+            "${tag_args[@]}"

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.dll
 *.so
 *.dylib
+rttys
 
 # Test binary, build with `go test -c`
 *.test

--- a/README.md
+++ b/README.md
@@ -64,6 +64,35 @@ Run the following command **as root** to install GLKVM Cloud:
 ( command -v curl >/dev/null 2>&1 && curl -fsSL https://kvm-cloud.gl-inet.com/selfhost/install.sh || wget -qO- https://kvm-cloud.gl-inet.com/selfhost/install.sh ) | sudo bash
 ```
 
+### 🐳 Universal Docker Build
+
+To package the platform as a Docker image on Linux, macOS, or Windows, use the
+cross-platform helper script in this repository:
+
+```bash
+python scripts/build_docker_image.py --image ghcr.io/wickedyoda/glkvm-cloud --tag latest
+```
+
+This command mirrors the installation script above by compiling the Go binary
+with the correct build metadata before assembling the Docker image defined in
+[`Dockerfile`](./Dockerfile). Add `--push` to publish the resulting tag to your
+container registry once you are authenticated with Docker.
+
+### 🧰 Docker Compose Deployment
+
+If you prefer managing the service with Docker Compose, the repository includes
+[`docker-compose.yml`](./docker-compose.yml) with sensible defaults. Update
+`rttys.conf` (and the optional certificate files) for your environment and then
+start the stack:
+
+```bash
+docker compose up -d
+```
+
+The compose file publishes the required TCP and UDP ports (443, 10443, 5912,
+and 3478) so the web interface, device connections, and TURN/WebRTC traffic can
+flow to the container.
+
 ### 🌐 Platform Access
 
 Once the installation is complete, access the platform via:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -64,6 +64,31 @@
 ( command -v curl >/dev/null 2>&1 && curl -fsSL https://kvm-cloud.gl-inet.com/selfhost/install.sh || wget -qO- https://kvm-cloud.gl-inet.com/selfhost/install.sh ) | sudo bash
 ```
 
+### 🐳 通用 Docker 构建
+
+在 Linux、macOS 或 Windows 上打包 Docker 镜像时，可以使用仓库提供的
+跨平台辅助脚本：
+
+```bash
+python scripts/build_docker_image.py --image ghcr.io/wickedyoda/glkvm-cloud --tag latest
+```
+
+该命令会按照安装脚本的方式编译 Go 二进制程序，并使用 [`Dockerfile`](./Dockerfile)
+构建镜像。登录容器仓库后，追加 `--push` 即可同步推送生成的标签。
+
+### 🧰 Docker Compose 部署
+
+如果你更习惯使用 Docker Compose 管理服务，可以直接使用仓库中的
+[`docker-compose.yml`](./docker-compose.yml)。根据实际环境修改 `rttys.conf`
+（以及可选的证书文件），然后运行：
+
+```bash
+docker compose up -d
+```
+
+该 Compose 文件已经映射所需的 TCP/UDP 端口（443、10443、5912 和 3478），
+确保 Web、设备连接以及 TURN/WebRTC 流量能够到达容器。
+
 ### 🌐 平台访问
 
 安装完成后，你可以通过以下方式访问平台：

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+
+services:
+  glkvm-cloud:
+    image: ghcr.io/wickedyoda/glkvm-cloud:latest
+    container_name: glkvm-cloud
+    restart: unless-stopped
+    # Update the bind mounts below with your customised configuration files.
+    volumes:
+      - ./rttys.conf:/etc/rttys/rttys.conf:ro
+      # - ./certificate:/etc/rttys/certificate:ro
+      # - ./turnserver.conf:/etc/turnserver.conf:ro
+    ports:
+      - "443:443"
+      - "10443:10443"
+      - "5912:5912"
+      - "3478:3478/tcp"
+      - "3478:3478/udp"
+    command: ["-c", "/etc/rttys/rttys.conf"]

--- a/scripts/build_docker_image.py
+++ b/scripts/build_docker_image.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Utility for building and publishing the GLKVM Cloud Docker image.
+
+This script replaces the legacy shell-based build helper so that the Docker
+image can be produced from Linux, macOS, and Windows alike.  It compiles the
+Go binary with the same metadata that the original shell script injected and
+then delegates to the local Docker installation to assemble the final image.
+
+Examples
+--------
+Build a local image tagged as ``latest``::
+
+    python scripts/build_docker_image.py --image ghcr.io/wickedyoda/glkvm-cloud
+
+Build and push images tagged as ``latest`` and ``dev``::
+
+    python scripts/build_docker_image.py \
+        --image ghcr.io/wickedyoda/glkvm-cloud \
+        --tag latest --tag dev --push
+
+The script assumes that ``go`` and ``docker`` are already installed and
+available on ``PATH``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+from typing import Iterable, List, Sequence
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _format_cmd(cmd: Sequence[object]) -> str:
+    """Return a human-friendly representation of *cmd* for logging."""
+
+    return " ".join(shlex.quote(str(part)) for part in cmd)
+
+
+def _run(cmd: Sequence[object], *, env: dict[str, str] | None = None) -> None:
+    """Execute *cmd* and raise :class:`RuntimeError` on failure."""
+
+    print(f"[build] $ {_format_cmd(cmd)}")
+    try:
+        subprocess.run(cmd, check=True, env=env)
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - CLI tool
+        raise RuntimeError(
+            f"Command failed with exit status {exc.returncode}: {_format_cmd(cmd)}"
+        ) from exc
+
+
+def _ensure_tool(name: str) -> None:
+    """Verify that *name* exists on ``PATH``."""
+
+    if shutil.which(name) is None:
+        raise RuntimeError(
+            f"Required executable '{name}' was not found on PATH. "
+            "Please install it before running this script."
+        )
+
+
+def _git(*args: str) -> str:
+    """Run a ``git`` command and return its stripped textual output."""
+
+    try:
+        return subprocess.check_output(("git",) + args, cwd=REPO_ROOT, text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def _build_binary(goos: str, goarch: str, output: Path) -> None:
+    """Compile the ``rttys`` binary for the requested platform."""
+
+    git_commit = _git("rev-parse", "--short", "HEAD")
+    build_time = (
+        _dt.datetime.now(_dt.timezone.utc)
+        .replace(microsecond=0)
+        .strftime("%Y-%m-%dT%H:%M:%S%z")
+    )
+
+    env = os.environ.copy()
+    env.update({
+        "GOOS": goos,
+        "GOARCH": goarch,
+        "CGO_ENABLED": "0",
+    })
+
+    ldflags = (
+        f"-s -w "
+        f"-X main.GitCommit={git_commit} "
+        f"-X main.BuildTime={build_time}"
+    )
+
+    # ``go build`` automatically chooses the main module in the repository root.
+    cmd: List[object] = [
+        "go",
+        "build",
+        "-trimpath",
+        "-ldflags",
+        ldflags,
+        "-o",
+        str(output),
+        ".",
+    ]
+
+    _run(cmd, env=env)
+
+    # Go on Windows respects the requested output name even if it does not end
+    # with ``.exe``; nonetheless we make the binary executable when possible.
+    try:
+        output.chmod(0o755)
+    except OSError:
+        pass
+
+
+def _build_image(
+    dockerfile: Path,
+    context: Path,
+    tags: Iterable[str],
+    platform: str | None,
+    build_args: Iterable[str],
+) -> None:
+    """Invoke ``docker build`` using the provided configuration."""
+
+    cmd: List[object] = ["docker", "build", "-f", str(dockerfile)]
+
+    for tag in tags:
+        cmd.extend(["-t", tag])
+
+    if platform:
+        cmd.extend(["--platform", platform])
+
+    for build_arg in build_args:
+        cmd.extend(["--build-arg", build_arg])
+
+    cmd.append(str(context))
+
+    _run(cmd)
+
+
+def _push(tags: Iterable[str]) -> None:
+    for tag in tags:
+        _run(["docker", "push", tag])
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument(
+        "--image",
+        default="ghcr.io/wickedyoda/glkvm-cloud",
+        help="Base image name (without tag) to use for the Docker build.",
+    )
+    parser.add_argument(
+        "--tag",
+        dest="tags",
+        action="append",
+        default=[],
+        help="Tag to apply to the built image (can be passed multiple times).",
+    )
+    parser.add_argument(
+        "--goos",
+        default="linux",
+        help="GOOS value used when compiling the binary (default: linux).",
+    )
+    parser.add_argument(
+        "--goarch",
+        default="amd64",
+        help="GOARCH value used when compiling the binary (default: amd64).",
+    )
+    parser.add_argument(
+        "--platform",
+        help=(
+            "Target platform passed to docker build (for example linux/amd64). "
+            "Defaults to the local Docker configuration."
+        ),
+    )
+    parser.add_argument(
+        "--dockerfile",
+        default="Dockerfile",
+        help="Path to the Dockerfile (default: Dockerfile).",
+    )
+    parser.add_argument(
+        "--context",
+        default=".",
+        help="Docker build context (default: current repository root).",
+    )
+    parser.add_argument(
+        "--build-arg",
+        dest="build_args",
+        action="append",
+        default=[],
+        help="Additional build arguments to forward to docker build.",
+    )
+    parser.add_argument(
+        "--push",
+        action="store_true",
+        help="Push the resulting image tags to the configured registry.",
+    )
+    parser.add_argument(
+        "--keep-binary",
+        action="store_true",
+        help="Do not delete the compiled binary after the Docker build completes.",
+    )
+
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+
+    # Resolve filesystem locations relative to the repository root.
+    dockerfile = (REPO_ROOT / args.dockerfile).resolve()
+    context = (REPO_ROOT / args.context).resolve()
+    binary_path = REPO_ROOT / "rttys"
+
+    if not dockerfile.exists():
+        raise RuntimeError(f"Dockerfile not found: {dockerfile}")
+
+    _ensure_tool("go")
+    _ensure_tool("docker")
+
+    if args.tags:
+        full_tags = [
+            tag if ":" in tag else f"{args.image}:{tag}"
+            for tag in args.tags
+        ]
+    else:
+        full_tags = [args.image] if ":" in args.image else [f"{args.image}:latest"]
+
+    print("[build] Compiling Go binary…")
+    _build_binary(args.goos, args.goarch, binary_path)
+
+    try:
+        print("[build] Building Docker image…")
+        _build_image(dockerfile, context, full_tags, args.platform, args.build_args)
+
+        if args.push:
+            print("[build] Pushing image tags…")
+            _push(full_tags)
+    finally:
+        if not args.keep_binary and binary_path.exists():
+            try:
+                binary_path.unlink()
+            except OSError:
+                pass
+
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    try:
+        raise SystemExit(main())
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- align the Docker build helper's timestamp format with the original shell script
- document Docker Compose usage in both the English and Chinese READMEs
- add a ready-to-use docker-compose.yml that publishes the required ports

## Testing
- python3 -m compileall scripts/build_docker_image.py

------
https://chatgpt.com/codex/tasks/task_e_68c89375f8d88323872631c17d21873a